### PR TITLE
Modify URL links in dashboard

### DIFF
--- a/components/Dashboard.js
+++ b/components/Dashboard.js
@@ -35,6 +35,7 @@ export default function Dashboard(props) {
           allData={props.data}
           headers={[dataField, 'Frequency']}
           updateDetailsPanel={props.updateSelectedValueDetails}
+          colecticaRepositoryHostname={props.colecticaRepositoryHostname}
         />
       </div>
     }) : `Error retrieving data, the Collectica API is not reachable. ${props.data.ErrorMessage}`

--- a/components/DataTable.js
+++ b/components/DataTable.js
@@ -10,7 +10,6 @@ export default function DataTable(props) {
       <ul>
         {selectedFieldValueInstances.map(selectedFieldInstance => {
           const url = `https://${props.colecticaRepositoryHostname}/item/${selectedFieldInstance.agency}/${selectedFieldInstance.studyUnitIdentifier}`
-          // const url = `https://discovery.closer.ac.uk/item/${selectedFieldInstance.agency}/${selectedFieldInstance.studyUnitIdentifier}`
           return <li><a target="_blank" href={url}>{url}</a></li>
         }
         )}

--- a/components/DataTable.js
+++ b/components/DataTable.js
@@ -9,7 +9,8 @@ export default function DataTable(props) {
     return <div><h2>{tableCell}</h2>
       <ul>
         {selectedFieldValueInstances.map(selectedFieldInstance => {
-          const url = `https://discovery.closer.ac.uk/item/${selectedFieldInstance.agency}/${selectedFieldInstance.studyUnitIdentifier}`
+          const url = `https://${props.colecticaRepositoryHostname}/item/${selectedFieldInstance.agency}/${selectedFieldInstance.studyUnitIdentifier}`
+          // const url = `https://discovery.closer.ac.uk/item/${selectedFieldInstance.agency}/${selectedFieldInstance.studyUnitIdentifier}`
           return <li><a target="_blank" href={url}>{url}</a></li>
         }
         )}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "dev": "SET NODE_EXTRA_CA_CERTS=public/www.ucl.ac.uk.cer &&SET COLECTICA_REPOSITORY_HOSTNAME=clsr-ppcolw01n.addev.ucl.ac.uk&&next dev",
+    "dev": "SET NODE_EXTRA_CA_CERTS=public/geant.pem &&SET COLECTICA_REPOSITORY_HOSTNAME=discovery.closer.ac.uk&&next dev",
     "start": "SET NODE_EXTRA_CA_CERTS=public/www.ucl.ac.uk.cer && next start",
     "test": "jest --env=jsdom"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "dev": "SET NODE_EXTRA_CA_CERTS=public/geant.pem &&SET COLECTICA_REPOSITORY_HOSTNAME=discovery.closer.ac.uk&&next dev",
+    "dev": "SET NODE_EXTRA_CA_CERTS=public/www.ucl.ac.uk.cer &&SET COLECTICA_REPOSITORY_HOSTNAME=clsr-ppcolw01n.addev.ucl.ac.uk&&next dev",
     "start": "SET NODE_EXTRA_CA_CERTS=public/www.ucl.ac.uk.cer && next start",
     "test": "jest --env=jsdom"
   },

--- a/pages/index.js
+++ b/pages/index.js
@@ -269,7 +269,9 @@ export async function getServerSideProps(context) {
 
   const username = !!context.req.cookies.username ? context.req.cookies.username : ""
 
-  const urlBase = `https://${process.env.COLECTICA_REPOSITORY_HOSTNAME}/api/v1`;
+  const colecticaRepositoryHostname = process.env.COLECTICA_REPOSITORY_HOSTNAME
+
+  const urlBase = `https://${colecticaRepositoryHostname}/api/v1`;
 
   const colecticaQueryResults = !!token ? await getDashboardData(context.req.cookies.token, urlBase) : {}
 
@@ -278,7 +280,8 @@ export async function getServerSideProps(context) {
       allPostsData,
       colecticaQueryResults,
       token,
-      username
+      username,
+      colecticaRepositoryHostname
     },
   };
 }
@@ -287,19 +290,21 @@ function displayDashboard(value,
   colecticaQueryResults, 
   handleChange, 
   selectedValueDetails, 
-  updateSelectedValueDetails) {
+  updateSelectedValueDetails,
+  colecticaRepositoryHostname) {
 
   return <Dashboard value={value}
     data={colecticaQueryResults}
     handleChange={handleChange}
     selectedValueDetails={selectedValueDetails}
     updateSelectedValueDetails={updateSelectedValueDetails}
+    colecticaRepositoryHostname={colecticaRepositoryHostname}
   />
 
 }
 
 
-export default function Home({ colecticaQueryResults, token, username }) {
+export default function Home({ colecticaQueryResults, token, username, colecticaRepositoryHostname }) {
 
   const [value, setValue] = useState(0);
 
@@ -313,7 +318,7 @@ export default function Home({ colecticaQueryResults, token, username }) {
   };
 
   return (
-    <Layout home token={token} username={username} setloginstatus={setLoginStatus}>
+    <Layout home token={token} username={username} setloginstatus={setLoginStatus} colecticaRepositoryHostname={colecticaRepositoryHostname}>
       The purpose of this tool is to identify specific item types which are entered as 
       'free text' for checking before deploying to production.
       {
@@ -323,7 +328,8 @@ export default function Home({ colecticaQueryResults, token, username }) {
             colecticaQueryResults, 
             handleChange, 
             selectedValueDetails, 
-            updateSelectedValueDetails)
+            updateSelectedValueDetails,
+            colecticaRepositoryHostname)
       }
 
     </Layout>


### PR DESCRIPTION
Modified dashboard so the urls it shows to users have the same hostname as the colectica repo that is being queried by the backend code. This hostname is specified in the dashboard config. Addresses https://github.com/CLOSER-Cohorts/dashboard/issues/43