### PR TITLE
Fix bug in reading last recorded number of records from file. 

### DIFF
--- a/lib/pollRepository.mjs
+++ b/lib/pollRepository.mjs
@@ -216,26 +216,27 @@ apiResponse.then(content => {
 
     fs.readFile('./data/repositoryItemCount.txt', 'utf8', (err, fileData) => {
       previousNumberOfItemsInRepository = !err ? !!fileData && JSON.parse(fileData)['TotalRevisions'] : "NA"
+
+
+      if (currentNumberOfItemsInRepository != previousNumberOfItemsInRepository) {
+        console.log("Mismatch between current and last recorded number of items. Updating reports.");
+
+        console.log("Current: " + currentNumberOfItemsInRepository)
+
+        console.log("Last recorded amount: " + previousNumberOfItemsInRepository)
+
+        fs.writeFile('./data/repositoryItemCount.txt', JSON.stringify(content), { flag: 'w+' }, writeErr => {
+          if (writeErr) {
+            console.error(writeErr);
+          } else {
+            // file written successfully
+          }
+
+          generateReports()
+        })
+
+      }
     });
-
-    if (currentNumberOfItemsInRepository != previousNumberOfItemsInRepository) {
-      console.log("Mismatch between current and last recorded number of items. Updating reports.");
-
-      console.log("Current: " + currentNumberOfItemsInRepository)
-
-      console.log("Last recorded amount: " + previousNumberOfItemsInRepository)
-
-      fs.writeFile('./data/repositoryItemCount.txt', JSON.stringify(content), { flag: 'w+' }, writeErr => {
-        if (writeErr) {
-          console.error(writeErr);
-        } else {
-          // file written successfully
-        }
-
-        generateReports()
-      })
-
-    }
 
   }
 


### PR DESCRIPTION
Due to a scoping issue, the number of records in the Colectica repository as recorded in the file data/repositoryItemCount.txt was not accessible by the code that compared that number to the the total number of records reported by the Colectica API output.

This branch just moves some code around so when comparing the number of records in the Colectica repository as reported by the API, and the number in repositoryItemCount.txt (which stores the number of records reported by the API the previous time the code ran), the code is able to access the updated value of the previousNumberOfItemsInRepository variable, and not just its initial value of 'undefined'.

This change is much simpler than appears, all it involved was nesting a bit of code inside another bit of code by moving an occurrence of  '})' (line 219 in previous version of this file) a bit further down (line 239 in code for this PR). Most of the changes here are by the Visual Studio formatter.