### PR TITLE
hide-content-from-logged-out-users

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -337,7 +337,7 @@ function displayDashboard(value,
   panelContents,
   tableData) {
 
-  return <GenericDashboard value={value}
+  return Object.keys(colecticaQueryResults).length > 0 ? <div><Navbar/><GenericDashboard value={value}
     data={colecticaQueryResults}
     handleChange={handleChange}
     selectedValueDetails={selectedValueDetails}
@@ -346,7 +346,7 @@ function displayDashboard(value,
     tabNames={tabNames}
     panelContents={panelContents}
     tableData={tableData}
-  />
+  /></div> : ""
 
 }
 
@@ -378,7 +378,6 @@ export default function Home({ colecticaQueryResults, token, username, colectica
      
   return (
     <Layout home token={token} username={username} setloginstatus={setLoginStatus} colecticaRepositoryHostname={colecticaRepositoryHostname} homepageRedirect={homepageRedirect}>
-      <Navbar/>
       The purpose of this dashboard is to identify specific item types which are entered as 
       'free text' for checking before deploying to production.
       {


### PR DESCRIPTION
At present tab headings and dashboard links are displayed on the dashboard to logged out users. These should not be displayed unless a user is logged in.