### PR TITLE
issue-78-remove-deprecated-items-from-dashboard

### DIFF
--- a/components/DataTable.js
+++ b/components/DataTable.js
@@ -18,7 +18,7 @@ export default function DataTable(props) {
 
   function tableRows() {
 
-    return (props.data[props.headers[0]].length!=0) ? !!props.data[props.headers[0]] && props.data[props.headers[0]].map((tableRow, index) => {
+    return (props.data[props.headers[0]]?.length!=0) ? !!props.data[props.headers[0]] && props.data[props.headers[0]].map((tableRow, index) => {
       return <tr key={index}>{tableCells(tableRow)}</tr>
       }) : <tr><td>No instances of this issue found.</td></tr>
 

--- a/lib/utility.mjs
+++ b/lib/utility.mjs
@@ -112,7 +112,7 @@ export function constructQueryBodyForGettingAllItems(type) {
     "ItemTypes": [type],
     "searchTerms": [''],
     "MaxResults": 0,
-    "searchDepricatedItems": 'True',
+    "searchDepricatedItems": 'False',
     "searchLatestVersion": 'True',
     "returnIdentifiersOnly": 'True'
   }


### PR DESCRIPTION
Addresses https://github.com/CLOSER-Cohorts/dashboard/issues/78.

Change function that generates POST body for Colectica API POST call that gets all items of a certain type so that the response doesn't include deprecated items.

Bug fix: modify code in DataTable component so it doesn't cause errors if an attempt is made to access an undefined property of an object.