### PR TITLE
Issue 109 fix polling for dashboard2

### DIFF
--- a/lib/pollRepository.mjs
+++ b/lib/pollRepository.mjs
@@ -162,15 +162,14 @@ async function retrieveDataInBatches(url, token, initialOffset, batchSize) {
   var allResults=[]
   var a ={"Results": []}
   var offset = initialOffset
+  
   while(offset == initialOffset || a['Results'].length==batchSize || a['Results'].length==0) {
     a=await executePostRequestWithToken(url, 
     token, 
     constructQueryBodyForGettingAllItems("683889c6-f74b-4d5e-92ed-908c0a42bb2d", batchSize, offset ))
   allResults=allResults.concat(a['Results'])
   offset=offset+10000
-}
-
-  
+  }
 
   return {'Results': allResults}
 }

--- a/lib/pollRepository.mjs
+++ b/lib/pollRepository.mjs
@@ -8,7 +8,7 @@ import {
 
 import fs from 'node:fs'
 
-const tokenObject = await getToken("user", "password", process.env.COLECTICA_REPOSITORY_HOSTNAME)
+const tokenObject = await getToken("o.lyttleton@ucl.ac.uk", "Plumber21Sonic!", process.env.COLECTICA_REPOSITORY_HOSTNAME)
 
 const token = tokenObject['access_token']
 
@@ -158,6 +158,32 @@ function findInvalidAgencies(items) {
 
 }
 
+async function retrieveDataInBatches(url, token, initialOffset, batchSize) {
+  var allResults=[]
+  var a ={"Results": []}
+  var offset = initialOffset
+  while(offset == initialOffset || a['Results'].length==batchSize || a['Results'].length==0) {
+    console.log("ARGS:")
+    console.log(batchSize)
+    console.log(offset)
+  a=await executePostRequestWithToken(url, 
+    token, 
+    constructQueryBodyForGettingAllItems("683889c6-f74b-4d5e-92ed-908c0a42bb2d", batchSize, offset ))
+  console.log("OUTPUT")
+  //console.log(a)
+  //console.log(!!a['Results'])
+  console.log(allResults.length) 
+  console.log(a['Results'].length) 
+  allResults=allResults.concat(a['Results'])
+  console.log(allResults.length)
+  offset=offset+10000
+}
+
+  
+
+  return {'Results': allResults}
+}
+
 async function generateReports() {
 
   const allPhysicalInstances = await executePostRequestWithToken(`${urlBase}/_query/`,
@@ -169,9 +195,12 @@ async function generateReports() {
   const allQuestionGrids = await executePostRequestWithToken(`${urlBase}/_query/`,
     token, constructQueryBodyForGettingAllItems("a1b8a30e-2f35-4056-8467-40e7ed0e7379"))
 
-  const allVariables = await executePostRequestWithToken(`${urlBase}/_query/`,
-    token, constructQueryBodyForGettingAllItems("683889c6-f74b-4d5e-92ed-908c0a42bb2d"))
+  const allVariables = await retrieveDataInBatches(`${urlBase}/_query/`,
+    token, 0, 10000)
 
+  console.log("NUM OF VARIABLES RETRIEVED: ")
+  console.log(allVariables['Results'].length)  
+  
   const allQuestionnaires = await executePostRequestWithToken(`${urlBase}/_query/`,
     token, constructQueryBodyForGettingAllItems("f196cc07-9c99-4725-ad55-5b34f479cf7d"))
     

--- a/lib/pollRepository.mjs
+++ b/lib/pollRepository.mjs
@@ -163,19 +163,10 @@ async function retrieveDataInBatches(url, token, initialOffset, batchSize) {
   var a ={"Results": []}
   var offset = initialOffset
   while(offset == initialOffset || a['Results'].length==batchSize || a['Results'].length==0) {
-    console.log("ARGS:")
-    console.log(batchSize)
-    console.log(offset)
-  a=await executePostRequestWithToken(url, 
+    a=await executePostRequestWithToken(url, 
     token, 
     constructQueryBodyForGettingAllItems("683889c6-f74b-4d5e-92ed-908c0a42bb2d", batchSize, offset ))
-  console.log("OUTPUT")
-  //console.log(a)
-  //console.log(!!a['Results'])
-  console.log(allResults.length) 
-  console.log(a['Results'].length) 
   allResults=allResults.concat(a['Results'])
-  console.log(allResults.length)
   offset=offset+10000
 }
 
@@ -198,9 +189,6 @@ async function generateReports() {
   const allVariables = await retrieveDataInBatches(`${urlBase}/_query/`,
     token, 0, 10000)
 
-  console.log("NUM OF VARIABLES RETRIEVED: ")
-  console.log(allVariables['Results'].length)  
-  
   const allQuestionnaires = await executePostRequestWithToken(`${urlBase}/_query/`,
     token, constructQueryBodyForGettingAllItems("f196cc07-9c99-4725-ad55-5b34f479cf7d"))
     

--- a/lib/pollRepository.mjs
+++ b/lib/pollRepository.mjs
@@ -8,7 +8,7 @@ import {
 
 import fs from 'node:fs'
 
-const tokenObject = await getToken("o.lyttleton@ucl.ac.uk", "Plumber21Sonic!", process.env.COLECTICA_REPOSITORY_HOSTNAME)
+const tokenObject = await getToken("user", "password", process.env.COLECTICA_REPOSITORY_HOSTNAME)
 
 const token = tokenObject['access_token']
 
@@ -18,19 +18,19 @@ const urlBase = `https://${repositoryHostname}/api/v1`;
 
 function writeUrnsToFile(resultList, fileName) {
 
-  if (resultList.length > 0) {
-
     var fileStreamWriter = fs.createWriteStream(`./data/${fileName}.txt`, { flags: 'w' })
 
-    resultList.forEach(result => {
+    if (resultList.length > 0) {
 
-      fileStreamWriter.write("urn:ddi:" + result['AgencyId'] + ":" + result['Identifier'] + ":" + result['Version'] + "\n")
+      resultList.forEach(result => {
 
-    })
+        fileStreamWriter.write("urn:ddi:" + result['AgencyId'] + ":" + result['Identifier'] + ":" + result['Version'] + "\n")
+
+      })
+
+    }
 
     fileStreamWriter.close()
-
-  }
 
 }
 

--- a/lib/utility.mjs
+++ b/lib/utility.mjs
@@ -107,11 +107,12 @@ export async function executePostRequestWithoutToken(url, requestBody) {
 
 }
 
-export function constructQueryBodyForGettingAllItems(type) {
+export function constructQueryBodyForGettingAllItems(type, maxResults=0, resultOffset=0) {
   return {
     "ItemTypes": [type],
     "searchTerms": [''],
-    "MaxResults": 0,
+    "MaxResults": maxResults,
+    "resultOffset": resultOffset,
     "searchDepricatedItems": 'False',
     "searchLatestVersion": 'True',
     "returnIdentifiersOnly": 'True'


### PR DESCRIPTION
Added function that allows 'chunked' queries, e.g. retrieve results in chunks of 10,000. Useful for queries which retrieve large numbers of results e.g. getting all variables.

Fixed bug in code that writes the results of polling to files, out-of-date results from previous runs weren't being deleted if there were no results returned for queries.