### PR TITLE
issue-108-add-timestamps-to-entries-in-logs

### DIFF
--- a/ecosystem.config.dist
+++ b/ecosystem.config.dist
@@ -6,6 +6,7 @@ module.exports = {
       script: "node_modules/next/dist/bin/next",
       args: "start", //running on port 3000
       watch: false,
+      time: true, //include timestamps in logs
       "env": {
       "NODE_EXTRA_CA_CERTS": "public/geant.pem",
       "COLECTICA_REPOSITORY_HOSTNAME": "enter hostname here",


### PR DESCRIPTION
Set 'time' flag to 'true' in config file for pm2 so that timestamps are included in pm2 log files